### PR TITLE
chore: claude settings in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ effective-pom.xml
 db.mv.db
 
 akka-context/
+.claude/settings.local.json
+


### PR DESCRIPTION
We have this in other samples. Approved permissions are stored in this file.